### PR TITLE
Add LangChain chat example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# 簡易AIチャット
+
+このリポジトリには、LangChain と OpenAI GPT-4o を利用した簡単なチャットプログラム `chat.py` が含まれています。
+
+## 使い方
+
+1. 必要なパッケージをインストールします。
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. `.env` ファイルを作成し、`OPENAI_API_KEY` を設定します。サンプルとして `.env.example` を用意しています。
+3. チャットを起動します。
+   ```bash
+   python chat.py
+   ```
+4. `exit` または `quit` を入力すると終了します。

--- a/chat.py
+++ b/chat.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+from langchain.chat_models import ChatOpenAI
+from langchain.schema import SystemMessage, HumanMessage
+
+
+def main() -> None:
+    """OpenAI GPT-4o を使ったシンプルなチャット"""
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY が設定されていません")
+
+    chat = ChatOpenAI(model_name="gpt-4o", openai_api_key=api_key)
+
+    system_message = SystemMessage(content="あなたは常に日本語で回答してください。")
+    print("'exit' または 'quit' で終了します。")
+
+    while True:
+        user_input = input("You: ")
+        if user_input.lower() in {"exit", "quit"}:
+            break
+        response = chat([system_message, HumanMessage(content=user_input)])
+        print("AI:", response.content)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+langchain
+langchain-openai
+python-dotenv


### PR DESCRIPTION
## Summary
- add simple `chat.py` to run GPT-4o via LangChain
- document usage in README
- provide example `.env` and dependencies
- ignore virtual environment artifacts

## Testing
- `git status --short`