### PR TITLE
Add MCP server and chat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,23 @@ python create_shapes_video.py
    - `shapes.mp4` に文字を 2 秒間重ねて `text.mp4` に保存
    - `shapes.mp4` を 2 倍速にして `fast.mp4` に保存
 3. `exit` または `quit` で終了します。
+
+## Playwright MCP サーバとブラウザ操作チャット
+
+`mcp-server` ディレクトリに Playwright MCP を利用した簡易サーバを用意しました。
+`ts-node` で起動できます。
+
+```bash
+cd mcp-server
+npm install        # 依存パッケージをインストール
+npm run start      # MCP サーバを起動
+```
+
+起動後、`mcp_chat.py` を実行すると MCP サーバをツールとして利用した
+ブラウザ操作チャットが起動します。
+
+```bash
+python mcp_chat.py
+```
+
+`exit` または `quit` で終了します。

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mcp-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "ts-node src/server.ts"
+  },
+  "dependencies": {
+    "playwright": "^1.43.0",
+    "playwright-mcp": "^0.1.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,0 +1,14 @@
+import { chromium } from 'playwright';
+import { startServer } from 'playwright-mcp';
+
+async function main() {
+  const browser = await chromium.launch();
+  const server = await startServer({ browser, port: 3322 });
+  console.log('MCP server listening on http://localhost:3322');
+  await server.waitForClose();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/mcp_chat.py
+++ b/mcp_chat.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+import requests
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
+from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.agents import create_openai_functions_agent, AgentExecutor
+from langchain.tools import tool
+
+MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://localhost:3322")
+
+@tool
+def open_page(url: str) -> str:
+    """MCPサーバで指定したURLを開きます"""
+    requests.post(f"{MCP_SERVER_URL}/open", json={"url": url})
+    return f"{url} を開きました"
+
+@tool
+def click(selector: str) -> str:
+    """MCPサーバでCSSセレクタを指定してクリックします"""
+    requests.post(f"{MCP_SERVER_URL}/click", json={"selector": selector})
+    return f"{selector} をクリックしました"
+
+
+def main() -> None:
+    """OpenAI GPT-4o と MCP サーバを使ったブラウザ操作チャット"""
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY が設定されていません")
+
+    llm = ChatOpenAI(model_name="gpt-4o", openai_api_key=api_key)
+    tools = [open_page, click]
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "あなたはブラウザ操作アシスタントです。指示に従い、MCPサーバを介してPlaywrightでブラウザを操作してください。",
+            ),
+            MessagesPlaceholder("chat_history", optional=True),
+            ("human", "{input}"),
+            MessagesPlaceholder("agent_scratchpad"),
+        ]
+    )
+
+    agent = create_openai_functions_agent(llm, tools, prompt)
+    agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
+
+    chat_history: list = []
+    print("'exit' または 'quit' で終了します。")
+    while True:
+        user_input = input("You: ")
+        if user_input.lower() in {"exit", "quit"}:
+            break
+        result = agent_executor.invoke({"input": user_input, "chat_history": chat_history})
+        print("AI:", result["output"])
+        chat_history.append(HumanMessage(content=user_input))
+        chat_history.append(AIMessage(content=result["output"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 moviepy
 numpy
 pillow
+requests


### PR DESCRIPTION
## Summary
- add `mcp-server` TypeScript project that starts a Playwright MCP server
- add `mcp_chat.py` to talk with the MCP server via LangChain tools
- update dependencies and documentation

## Testing
- `git status --short`